### PR TITLE
Adding a fromString to all SRIs to accomondate default Deserializatio…

### DIFF
--- a/snice-testing-core/src/main/java/io/snice/identity/sri/AccountResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/AccountResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class AccountResourceIdentifier extends SniceResourceIdentifier.Bas
         return from(PREFIX, sri, AccountResourceIdentifier::new);
     }
 
+    public static AccountResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static AccountResourceIdentifier of() {
         return new AccountResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/ActionResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/ActionResourceIdentifier.java
@@ -19,6 +19,10 @@ public final class ActionResourceIdentifier extends SniceResourceIdentifier.Base
         return from(PREFIX, sri, ActionResourceIdentifier::new);
     }
 
+    public static ActionResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static ActionResourceIdentifier of() {
         return new ActionResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/DeploymentResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/DeploymentResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class DeploymentResourceIdentifier extends SniceResourceIdentifier.
         return from(PREFIX, sri, DeploymentResourceIdentifier::new);
     }
 
+    public static DeploymentResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static DeploymentResourceIdentifier of() {
         return new DeploymentResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/OrganizationResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/OrganizationResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class OrganizationResourceIdentifier extends SniceResourceIdentifie
         return from(PREFIX, sri, OrganizationResourceIdentifier::new);
     }
 
+    public static OrganizationResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static OrganizationResourceIdentifier of() {
         return new OrganizationResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/RepositoryResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/RepositoryResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class RepositoryResourceIdentifier extends SniceResourceIdentifier.
         return from(PREFIX, sri, RepositoryResourceIdentifier::new);
     }
 
+    public static RepositoryResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static RepositoryResourceIdentifier of() {
         return new RepositoryResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/ScenarioResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/ScenarioResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class ScenarioResourceIdentifier extends SniceResourceIdentifier.Ba
         return from(PREFIX, sri, ScenarioResourceIdentifier::new);
     }
 
+    public static ScenarioResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static ScenarioResourceIdentifier of() {
         return new ScenarioResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/SessionResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/SessionResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class SessionResourceIdentifier extends SniceResourceIdentifier.Bas
         return from(PREFIX, sri, SessionResourceIdentifier::new);
     }
 
+    public static SessionResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static SessionResourceIdentifier of() {
         return new SessionResourceIdentifier(SniceResourceIdentifier.uuid());
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/SniceResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/SniceResourceIdentifier.java
@@ -36,6 +36,7 @@ public sealed interface SniceResourceIdentifier permits ActionResourceIdentifier
      */
     Buffer raw();
 
+
     default String asString() {
         return prefix() + raw().toHexString(false);
     }

--- a/snice-testing-core/src/main/java/io/snice/identity/sri/UserResourceIdentifier.java
+++ b/snice-testing-core/src/main/java/io/snice/identity/sri/UserResourceIdentifier.java
@@ -14,6 +14,10 @@ public final class UserResourceIdentifier extends SniceResourceIdentifier.BaseRe
         return from(PREFIX, sri, UserResourceIdentifier::new);
     }
 
+    public static UserResourceIdentifier fromString(final String sri) {
+        return from(sri);
+    }
+
     public static UserResourceIdentifier of() {
         return new UserResourceIdentifier(SniceResourceIdentifier.uuid());
     }


### PR DESCRIPTION
…n support from Jetty

In Jetty (and I assume it is som JAX-RS whatever specification thing), when deserializing incoming webtraffic, such as a form param or a path param, from a string into a java object, it will by default look for a static method called fromString. If it exists, it'll use it. If not, you would have to wrap that into a "param converter" instead.

This seemed simpler and doesn't really break the non-dependency on irrelevant frameworks for these simple POJOs (I wouldn't have done it if I actually had to be dependent on some jax-rs stuff).